### PR TITLE
remove test_case from tests and hypothesis from systems

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -202,13 +202,11 @@ def pytest_addoption(parser):
         nargs='+',
         default=[
             'accounts', 'biglearn', 'exercises',
-            'hypothesis', 'payments', 'support',
-            'tutor', 'web'],
+            'payments', 'support', 'tutor', 'web'],
         help=(
             'Systems under test\n'
             'Options: accounts, biglearn, exercises\n'
-            '         hypothesis, payments, support,\n'
-            '         tutor, web'))
+            '         payments, support, tutor, web'))
 
 
 def pytest_collection_modifyitems(config, items):
@@ -232,6 +230,9 @@ def pytest_collection_modifyitems(config, items):
     deselected = []
     remaining = []
     for item in items:
+        if '<Function test_case>' in str(item):
+            deselected.append(item)
+            continue
         if run_smoke_tests:
             if 'smoke_test' not in item.keywords:
                 deselected.append(item)
@@ -253,10 +254,6 @@ def pytest_collection_modifyitems(config, items):
                 deselected.append(item)
                 continue
             if 'exercises' not in run_systems and 'exercises' in item.keywords:
-                deselected.append(item)
-                continue
-            if ('hypothesis' not in run_systems
-                    and 'hypothesis' in item.keywords):
                 deselected.append(item)
                 continue
             if 'payments' not in run_systems and 'payments' in item.keywords:

--- a/tests/markers.py
+++ b/tests/markers.py
@@ -6,7 +6,6 @@ from pytest_testrail.plugin import pytestrail
 accounts = pytest.mark.accounts
 biglearn = pytest.mark.biglearn
 exercises = pytest.mark.exercises
-hypothesis = pytest.mark.hypothesis
 payments = pytest.mark.payments
 support = pytest.mark.support
 tutor = pytest.mark.tutor

--- a/utils/tutor.py
+++ b/utils/tutor.py
@@ -47,6 +47,11 @@ class Tutor(object):
     IS_PREVIEW = 'is preview'
     IS_TEACHER = 'is teacher'
 
+    # Scores
+
+    AS_NUMBER = 'number'
+    AS_PERCENTAGE = 'percentage'
+
 
 class TutorException(WebDriverException):
     """A generic exception for Tutor."""


### PR DESCRIPTION
hypothesis has been fully incorporated into Tutor so remove it from the standing list of system options
strip test_case plugin tests for possible