### PR TITLE
added autochomsky==1.0.5 to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 alabaster==0.7.12
 apipkg==1.5
 asn1crypto==0.24.0
+autochomsky==1.0.5
 Babel==2.6.0
 beautifulsoup4==4.6.0
 bs4==0.0.1


### PR DESCRIPTION
Brooke received an error that she was not able to import the autochomsky module. This was due to it not being installed in her virtualenv and not included in the requirements.txt file.